### PR TITLE
feat: Add required app version and app build number arguments in login config

### DIFF
--- a/example/App.tsx
+++ b/example/App.tsx
@@ -7,7 +7,9 @@ export default function App() {
       <RNInfomaniakOnboardingView
         loginConfiguration={{
           clientId: '20af5539-a4fb-421c-b45a-f43af3d90c14',
-          redirectURIScheme: 'com.infomaniak.chat'
+          redirectURIScheme: 'com.infomaniak.chat',
+          appVersionCode: 18,
+          appVersionName: '0.2.5',
         }}
         onboardingConfiguration={{
           primaryColorLight: '#0088B2',

--- a/src/RNInfomaniakOnboarding.types.ts
+++ b/src/RNInfomaniakOnboarding.types.ts
@@ -22,6 +22,8 @@ export type LoginConfiguration = {
   clientId: string;
   loginURL?: string; // defaults to "https://login.infomaniak.com/"
   redirectURIScheme: string; // The "appbundleid" part in the redirect URI of the form "appbundleid://oauth2redirect"
+  appVersionCode: number; // The Android build number. For api call headers and the user agent
+  appVersionName: string; // App version like "2.14.8". For api call headers and the user agent
 };
 
 export type OnLoginSuccessEventPayload = {


### PR DESCRIPTION
This is used in the headers of the api calls. For the "App-Version" header and for the user agent header