### PR TITLE
feat: Return a list of multiple access tokens and take it as argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ## How to use this library in an Expo module
 
 This library provides a RNInfomaniakOnboardingView component that displays the onboarding screens and manages the entire login
-flow. After a successful login, the view returns an access token.
+flow. After a successful login, the view returns a list of access tokens.
 
 ### Basic usage
 ```tsx
@@ -14,7 +14,7 @@ flow. After a successful login, the view returns an access token.
     onboardingConfiguration={{
     ...
     }}
-    onLoginSuccess={(accessToken) => console.log(event.nativeEvent.accessToken)}
+    onLoginSuccess={(event) => console.log(event.nativeEvent.accessTokens)}
     onLoginError={(event) => console.error(event.nativeEvent.error)}
 />
 ```

--- a/android/src/main/java/com/infomaniak/nativeonboarding/RNInfomaniakOnboardingView.kt
+++ b/android/src/main/java/com/infomaniak/nativeonboarding/RNInfomaniakOnboardingView.kt
@@ -24,7 +24,7 @@ import expo.modules.kotlin.AppContext
 import expo.modules.kotlin.viewevent.EventDispatcher
 import expo.modules.kotlin.views.ExpoView
 
-private const val SUCCESS_EVENT_KEY = "accessToken"
+private const val SUCCESS_EVENT_KEY = "accessTokens"
 private const val ERROR_EVENT_KEY = "error"
 
 class RNInfomaniakOnboardingView(context: Context, appContext: AppContext) : ExpoView(context, appContext) {

--- a/android/src/main/java/com/infomaniak/nativeonboarding/models/LoginConfiguration.kt
+++ b/android/src/main/java/com/infomaniak/nativeonboarding/models/LoginConfiguration.kt
@@ -13,8 +13,10 @@ data class LoginConfiguration(
     @Field var createAccountUrl: String,
     @Field("successHost") private var _successHost: String?,
     @Field("cancelHost") private var _cancelHost: String?,
+    @Field private var allowMultipleAccounts: Boolean,
 ) : Record {
     val loginUrl: String get() = loginURL ?: "https://login.infomaniak.com/"
     val successHost: String get() = _successHost ?: "ksuite.infomaniak.com"
     val cancelHost: String get() = _cancelHost ?: "welcome.infomaniak.com"
+    val isSingleSelection: Boolean get() = allowMultipleAccounts.not()
 }

--- a/example/App.tsx
+++ b/example/App.tsx
@@ -11,6 +11,7 @@ export default function App() {
           appVersionCode: 18,
           appVersionName: '0.2.5',
           createAccountUrl: "https://welcome.infomaniak.com/signup/ikmail?app=true",
+          allowMultipleAccounts: true,
         }}
         onboardingConfiguration={{
           primaryColorLight: '#0088B2',
@@ -63,7 +64,7 @@ export default function App() {
           ],
         }}
         onLoginSuccess={(event) => {
-          Alert.alert('Login Success', event.nativeEvent.accessToken);
+          Alert.alert('Login Success', event.nativeEvent.accessTokens);
         }}
         onLoginError={(event) => {
           console.error(`Login Error: ${event.nativeEvent.error}`);

--- a/src/RNInfomaniakOnboarding.types.ts
+++ b/src/RNInfomaniakOnboarding.types.ts
@@ -37,6 +37,7 @@ export type LoginConfiguration = {
   createAccountUrl: string; // Url to create the account specific to this app. E.g. https://welcome.infomaniak.com/signup/...
   successHost?: string; // Url to detect that the login has finished with success. By default "ksuite.infomaniak.com"
   cancelHost?: string; // Url to detect that the login has finished with an error. By default "welcome.infomaniak.com"
+  allowMultipleAccounts: boolean; // If the cross app login should limit to only one account or allow the selection of any amount of accounts
 };
 
 export type OnLoginSuccessEventPayload = {


### PR DESCRIPTION
Always return a list of access tokens so supporting single or multiple account selection is the same. Also add a config login argument to configure this selection behavior