### PR TITLE
fix: Add missing OnLoginSuccessEventPayload typing for accessTokens

### DIFF
--- a/example/App.tsx
+++ b/example/App.tsx
@@ -64,7 +64,7 @@ export default function App() {
           ],
         }}
         onLoginSuccess={(event) => {
-          Alert.alert('Login Success', event.nativeEvent.accessTokens);
+          Alert.alert('Login Success', event.nativeEvent.accessTokens.join(", "));
         }}
         onLoginError={(event) => {
           console.error(`Login Error: ${event.nativeEvent.error}`);

--- a/src/RNInfomaniakOnboarding.types.ts
+++ b/src/RNInfomaniakOnboarding.types.ts
@@ -41,7 +41,7 @@ export type LoginConfiguration = {
 };
 
 export type OnLoginSuccessEventPayload = {
-  accessToken: string;
+  accessTokens: string[];
 };
 
 export type OnLoginErrorEventPayload = {


### PR DESCRIPTION
The code that consumes it was updated but not the typing definition