### PR TITLE
feat: Support multiple accounts

### DIFF
--- a/android/src/main/java/com/infomaniak/nativeonboarding/OnboardingEvents.kt
+++ b/android/src/main/java/com/infomaniak/nativeonboarding/OnboardingEvents.kt
@@ -13,13 +13,11 @@ interface OnboardingEvents {
     val onLoginError: ViewEventCallback<Map<String, Any>>
 
     fun reportAccessToken(accessToken: String) {
-        onLoginSuccess(mapOf(SUCCESS_EVENT_KEY to listOf(accessToken)))
+        reportAccessTokens(listOf(accessToken))
     }
 
     fun reportAccessTokens(accessTokens: List<String>) {
-        if (accessTokens.isNotEmpty()) {
-            onLoginSuccess(mapOf(SUCCESS_EVENT_KEY to accessTokens))
-        }
+        onLoginSuccess(mapOf(SUCCESS_EVENT_KEY to accessTokens))
     }
 
     fun reportMissingIllustration() {

--- a/android/src/main/java/com/infomaniak/nativeonboarding/OnboardingEvents.kt
+++ b/android/src/main/java/com/infomaniak/nativeonboarding/OnboardingEvents.kt
@@ -1,0 +1,45 @@
+package com.infomaniak.nativeonboarding
+
+import android.content.Context
+import com.infomaniak.nativeonboarding.models.AnimatedIllustration
+import com.infomaniak.nativeonboarding.models.StaticIllustration
+import expo.modules.kotlin.viewevent.ViewEventCallback
+
+private const val SUCCESS_EVENT_KEY = "accessTokens"
+private const val ERROR_EVENT_KEY = "error"
+
+interface OnboardingEvents {
+    val onLoginSuccess: ViewEventCallback<Map<String, Any>>
+    val onLoginError: ViewEventCallback<Map<String, Any>>
+
+    fun reportAccessToken(accessToken: String) {
+        onLoginSuccess(mapOf(SUCCESS_EVENT_KEY to listOf(accessToken)))
+    }
+
+    fun reportAccessTokens(accessTokens: List<String>) {
+        if (accessTokens.isNotEmpty()) {
+            onLoginSuccess(mapOf(SUCCESS_EVENT_KEY to accessTokens))
+        }
+    }
+
+    fun reportMissingIllustration() {
+        reportError("Missing illustration. Provide either a StaticIllustration or an AnimatedIllustration instance in each slide")
+    }
+
+    fun AnimatedIllustration.reportErrors(context: Context) {
+        if (fileName.assetFileExists(context).not()) reportMissingAsset(fileName)
+    }
+
+    fun StaticIllustration.reportErrors(context: Context) {
+        if (androidDarkFileName.assetFileExists(context).not()) reportMissingAsset(androidDarkFileName)
+        if (androidLightFileName.assetFileExists(context).not()) reportMissingAsset(androidLightFileName)
+    }
+
+    private fun reportError(errorMessage: String) {
+        onLoginError(mapOf(ERROR_EVENT_KEY to errorMessage))
+    }
+
+    private fun reportMissingAsset(fileName: String) {
+        reportError("Missing file '$fileName' in Android assets folders")
+    }
+}

--- a/android/src/main/java/com/infomaniak/nativeonboarding/OnboardingScreen.kt
+++ b/android/src/main/java/com/infomaniak/nativeonboarding/OnboardingScreen.kt
@@ -42,6 +42,7 @@ fun OnboardingScreen(
     pages: SnapshotStateList<Page>,
     accountsCheckingState: () -> AccountsCheckingState,
     skippedIds: () -> Set<Long>,
+    isSingleSelection: Boolean,
     isLoginButtonLoading: () -> Boolean,
     isSignUpButtonLoading: () -> Boolean,
     onLoginRequest: (accounts: List<ExternalAccount>) -> Unit,
@@ -72,7 +73,7 @@ fun OnboardingScreen(
                     isLoginButtonLoading = isLoginButtonLoading,
                     isSignUpButtonLoading = isSignUpButtonLoading,
                 ),
-                isSingleSelection = true,
+                isSingleSelection = isSingleSelection,
             )
         },
         snackbarHost = { SnackbarHost(snackbarHostState) },
@@ -133,11 +134,12 @@ private fun Preview(
                     AccountsCheckingState(status = AccountsCheckingStatus.Checking, checkedAccounts = accounts)
                 },
                 skippedIds = { emptySet() },
+                isSingleSelection = false,
+                isLoginButtonLoading = { false },
+                isSignUpButtonLoading = { false },
                 onLoginRequest = {},
                 onCreateAccount = {},
                 onSaveSkippedAccounts = {},
-                isLoginButtonLoading = { false },
-                isSignUpButtonLoading = { false },
                 snackbarHostState = SnackbarHostState(),
             )
         }

--- a/android/src/main/java/com/infomaniak/nativeonboarding/RNInfomaniakOnboardingView.kt
+++ b/android/src/main/java/com/infomaniak/nativeonboarding/RNInfomaniakOnboardingView.kt
@@ -44,14 +44,11 @@ import expo.modules.kotlin.viewevent.EventDispatcher
 import expo.modules.kotlin.views.ExpoView
 import kotlinx.coroutines.launch
 
-private const val SUCCESS_EVENT_KEY = "accessTokens"
-private const val ERROR_EVENT_KEY = "error"
-
-class RNInfomaniakOnboardingView(context: Context, appContext: AppContext) : ExpoView(context, appContext) {
+class RNInfomaniakOnboardingView(context: Context, appContext: AppContext) : ExpoView(context, appContext), OnboardingEvents {
     // Creates and initializes an event dispatcher for the `onLoginSuccess` and `onLoginError` events.
     // The name of the event is inferred from the value and needs to match the event name defined in the module.
-    private val onLoginSuccess by EventDispatcher()
-    private val onLoginError by EventDispatcher()
+    override val onLoginSuccess by EventDispatcher()
+    override val onLoginError by EventDispatcher()
 
     private var loginData: LoginData? by mutableStateOf(null)
     private val pages = mutableStateListOf<Page>()
@@ -130,11 +127,11 @@ class RNInfomaniakOnboardingView(context: Context, appContext: AppContext) : Exp
         pages.addAll(config.slides)
 
         pages.forEach { page ->
-            page.backgroundImage.reportErrors()
+            page.backgroundImage.reportErrors(context)
 
             when (val illustration = page.animatedIllustration ?: page.staticIllustration) {
-                is AnimatedIllustration -> illustration.reportErrors()
-                is StaticIllustration -> illustration.reportErrors()
+                is AnimatedIllustration -> illustration.reportErrors(context)
+                is StaticIllustration -> illustration.reportErrors(context)
                 null -> reportMissingIllustration()
             }
         }
@@ -218,37 +215,6 @@ class RNInfomaniakOnboardingView(context: Context, appContext: AppContext) : Exp
 
     private fun stopLoadingLoginButtons() {
         areButtonsLoading = false
-    }
-
-    private fun reportAccessToken(accessToken: String) {
-        onLoginSuccess(mapOf(SUCCESS_EVENT_KEY to listOf(accessToken)))
-    }
-
-    private fun reportAccessTokens(accessTokens: List<String>) {
-        if (accessTokens.isNotEmpty()) {
-            onLoginSuccess(mapOf(SUCCESS_EVENT_KEY to accessTokens))
-        }
-    }
-
-    private fun reportError(errorMessage: String) {
-        onLoginError(mapOf(ERROR_EVENT_KEY to errorMessage))
-    }
-
-    private fun reportMissingAsset(fileName: String) {
-        reportError("Missing file '$fileName' in Android assets folders")
-    }
-
-    private fun reportMissingIllustration() {
-        reportError("Missing illustration. Provide either a StaticIllustration or an AnimatedIllustration instance in each slide")
-    }
-
-    private fun AnimatedIllustration.reportErrors() {
-        if (fileName.assetFileExists(context).not()) reportMissingAsset(fileName)
-    }
-
-    private fun StaticIllustration.reportErrors() {
-        if (androidDarkFileName.assetFileExists(context).not()) reportMissingAsset(androidDarkFileName)
-        if (androidLightFileName.assetFileExists(context).not()) reportMissingAsset(androidLightFileName)
     }
 
     companion object {

--- a/android/src/main/java/com/infomaniak/nativeonboarding/RNInfomaniakOnboardingView.kt
+++ b/android/src/main/java/com/infomaniak/nativeonboarding/RNInfomaniakOnboardingView.kt
@@ -62,67 +62,67 @@ class RNInfomaniakOnboardingView(context: Context, appContext: AppContext) : Exp
     private var areButtonsLoading by mutableStateOf(false)
 
     init {
-        addView(ComposeView(context).apply {
-            setContent {
-                val scope = rememberCoroutineScope()
-                val snackbarHostState = remember { SnackbarHostState() }
+        val composeView = ComposeView(context)
+        composeView.setContent {
+            val scope = rememberCoroutineScope()
+            val snackbarHostState = remember { SnackbarHostState() }
 
-                loginData?.let { loginData ->
-                    val crossAppLoginViewModel = viewModel<CrossAppLoginViewModel>(
-                        factory = CrossAppLoginViewModelFactory(loginData.applicationId, loginData.clientId)
-                    )
+            loginData?.let { loginData ->
+                val crossAppLoginViewModel = viewModel<CrossAppLoginViewModel>(
+                    factory = CrossAppLoginViewModelFactory(loginData.applicationId, loginData.clientId)
+                )
 
-                    val hostActivity = LocalActivity.current as ComponentActivity
-                    LaunchedEffect(crossAppLoginViewModel) {
-                        crossAppLoginViewModel.activateUpdates(hostActivity, singleSelection = loginData.isSingleSelection)
-                    }
-
-                    val accounts by crossAppLoginViewModel.accountsCheckingState.collectAsStateWithLifecycle()
-                    val skippedIds by crossAppLoginViewModel.skippedAccountIds.collectAsStateWithLifecycle()
-
-                    Log.i(TAG, "Got ${accounts.checkedAccounts.count()} accounts from other apps")
-
-                    val loginFlowController = LoginUtils.rememberLoginFlowController(
-                        infomaniakLogin = loginData.infomaniakLogin,
-                        userExistenceChecker = userExistenceChecker,
-                    ) { userLoginResult ->
-                        when (userLoginResult) {
-                            is UserLoginResult.Success -> reportAccessToken(userLoginResult.user.apiToken.accessToken)
-                            is UserLoginResult.Failure -> scope.launch { snackbarHostState.showSnackbar(userLoginResult.errorMessage) }
-                            null -> Unit
-                        }
-
-                        if (userLoginResult !is UserLoginResult.Success) stopLoadingLoginButtons()
-                    }
-
-                    OnboardingViewContent(
-                        pages = pages,
-                        colors = { onboardingArgumentColors },
-                        accounts = { accounts },
-                        skippedIds = { skippedIds },
-                        isSingleSelection = loginData.isSingleSelection,
-                        isLoginButtonLoading = { areButtonsLoading },
-                        isSignUpButtonLoading = { areButtonsLoading },
-                        onLoginRequest = { accounts ->
-                            if (accounts.isEmpty()) {
-                                openLoginWebView(loginFlowController)
-                            } else {
-                                scope.launch {
-                                    connectSelectedAccounts(
-                                        accounts,
-                                        crossAppLoginViewModel,
-                                        snackbarHostState
-                                    )
-                                }
-                            }
-                        },
-                        onCreateAccount = { openAccountCreation(loginFlowController, loginData) },
-                        onSaveSkippedAccounts = { crossAppLoginViewModel.skippedAccountIds.value = it },
-                        snackbarHostState = snackbarHostState,
-                    )
+                val hostActivity = LocalActivity.current as ComponentActivity
+                LaunchedEffect(crossAppLoginViewModel) {
+                    crossAppLoginViewModel.activateUpdates(hostActivity, singleSelection = loginData.isSingleSelection)
                 }
+
+                val accounts by crossAppLoginViewModel.accountsCheckingState.collectAsStateWithLifecycle()
+                val skippedIds by crossAppLoginViewModel.skippedAccountIds.collectAsStateWithLifecycle()
+
+                Log.i(TAG, "Got ${accounts.checkedAccounts.count()} accounts from other apps")
+
+                val loginFlowController = LoginUtils.rememberLoginFlowController(
+                    infomaniakLogin = loginData.infomaniakLogin,
+                    userExistenceChecker = userExistenceChecker,
+                ) { userLoginResult ->
+                    when (userLoginResult) {
+                        is UserLoginResult.Success -> reportAccessToken(userLoginResult.user.apiToken.accessToken)
+                        is UserLoginResult.Failure -> scope.launch { snackbarHostState.showSnackbar(userLoginResult.errorMessage) }
+                        null -> Unit
+                    }
+
+                    if (userLoginResult !is UserLoginResult.Success) stopLoadingLoginButtons()
+                }
+
+                OnboardingViewContent(
+                    pages = pages,
+                    colors = { onboardingArgumentColors },
+                    accounts = { accounts },
+                    skippedIds = { skippedIds },
+                    isSingleSelection = loginData.isSingleSelection,
+                    isLoginButtonLoading = { areButtonsLoading },
+                    isSignUpButtonLoading = { areButtonsLoading },
+                    onLoginRequest = { accounts ->
+                        if (accounts.isEmpty()) {
+                            openLoginWebView(loginFlowController)
+                        } else {
+                            scope.launch {
+                                connectSelectedAccounts(
+                                    accounts,
+                                    crossAppLoginViewModel,
+                                    snackbarHostState
+                                )
+                            }
+                        }
+                    },
+                    onCreateAccount = { openAccountCreation(loginFlowController, loginData) },
+                    onSaveSkippedAccounts = { crossAppLoginViewModel.skippedAccountIds.value = it },
+                    snackbarHostState = snackbarHostState,
+                )
             }
-        })
+        }
+        addView(composeView)
     }
 
     fun setOnboardingConfig(config: OnboardingConfiguration) {


### PR DESCRIPTION
Better reviewed by hiding white spaces because I removed one useless indent level.

Read the provided LoginConfig argument that tells if cross app login needs to support multiple account or a single one.

Depends on #26 